### PR TITLE
Added support of refArDo element, as required for parsing profiles cr…

### DIFF
--- a/lpad-sm-dp-plus-connector/src/main/java/com/truphone/es9plus/HttpRSPClient.java
+++ b/lpad-sm-dp-plus-connector/src/main/java/com/truphone/es9plus/HttpRSPClient.java
@@ -22,11 +22,10 @@ public class HttpRSPClient {
                                          final String url) throws Exception {
 
         Pair<String, String> contentType = new Pair<>("Content-Type", "application/json");
-        Pair<String, String> accept = new Pair<>("Accept", "application/json");
         Pair<String, String> userAgent = new Pair<>("User-Agent", "gsma-rsp-com.truphone.lpad");
         Pair<String, String> xAdminProtocol = new Pair<>("X-Admin-Protocol", "gsma/rsp/v2.2.0");
 
-        return invoke("POST", body, rspServerUrl, url, Arrays.asList(contentType, accept, userAgent, xAdminProtocol));
+        return invoke("POST", body, rspServerUrl, url, Arrays.asList(contentType, userAgent, xAdminProtocol));
     }
 
     public HttpResponse clientSimpleRequest(final String body,

--- a/lpad-sm-dp-plus-connector/src/main/resources/rsp.asn
+++ b/lpad-sm-dp-plus-connector/src/main/resources/rsp.asn
@@ -158,7 +158,18 @@ ProfileInfo ::= [PRIVATE 3] SEQUENCE { -- Tag 'E3'
     notificationConfigurationInfo [22] SEQUENCE OF NotificationConfigurationInformation OPTIONAL, -- Tag 'B6'
     profileOwner [23] OperatorID OPTIONAL, -- Tag 'B7'
     dpProprietaryData [24] DpProprietaryData OPTIONAL, -- Tag 'B8'
-    profilePolicyRules [25] PprIds OPTIONAL -- Tag '99'
+    profilePolicyRules [25] PprIds OPTIONAL, -- Tag '99'
+    refArDo [118] SEQUENCE OF RefArDo OPTIONAL -- Tag 'BF76'
+}
+
+RefArDo ::= [PRIVATE 2] SEQUENCE {  -- Tag 'E2'
+    refDo [PRIVATE 1] SEQUENCE {  -- Tag 'E1'
+        deviceAppIdRefDo [PRIVATE 1] OCTET STRING (SIZE(20|32)),  -- Tag 'C1'
+        pkgRefDo [PRIVATE 10] OCTET STRING (SIZE(0..127)) OPTIONAL  -- Tag 'CA'
+    },
+    arDo [PRIVATE 3] SEQUENCE {  -- Tag 'E3'
+        permArDo [PRIVATE 27] OCTET STRING (SIZE(8))  -- Tag 'DB'
+    }
 }
  
 PprIds ::= BIT STRING {-- Definition of Profile Policy Rules identifiers


### PR DESCRIPTION
[Here](https://source.android.com/docs/core/connect/esim-overview) under carrier privileges, there is an additional element added to the ProfileInfo sequence.
Without this it's not possible to parse profiles created by newer Android versions.
This PR adds it to the ASN1 definitions